### PR TITLE
Add TEST conditional to CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ include_directories(include)
 
 file(GLOB SOURCES "src/*.cpp")
 
-option(TEST "Run tests only? (No build)" OFF)
+option(TEST "Run tests only?" OFF)
+message(STATUS "Run tests only = " ${TEST})
 
 if(TEST)
     add_executable(elapsed_time_formatter test/format.test.cpp src/format.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.13)
-project(monitor)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+project(monitor LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -12,19 +12,21 @@ include_directories(include)
 
 file(GLOB SOURCES "src/*.cpp")
 
-# uncomment for build
-add_executable(monitor ${SOURCES})
-target_link_libraries(monitor ${CURSES_LIBRARIES})
-# TODO: Run -Werror in CI.
-target_compile_options(monitor PRIVATE -Wall -Wextra)
+option(TEST "Run tests only? (No build)" OFF)
 
-# uncomment for test
-add_executable(elapsed_time_formatter test/format.test.cpp src/format.cpp)
-enable_testing()
-add_test(
-        NAME elapsed_time_formatter
-        COMMAND $<TARGET_FILE:elapsed_time_formatter>
-)
+if(TEST)
+    add_executable(elapsed_time_formatter test/format.test.cpp src/format.cpp)
+    enable_testing()
+    add_test(
+            NAME elapsed_time_formatter
+            COMMAND $<TARGET_FILE:elapsed_time_formatter>
+    )
+else()
+    add_executable(monitor ${SOURCES})
+    target_link_libraries(monitor ${CURSES_LIBRARIES})
+    # TODO: Run -Werror in CI.
+    target_compile_options(monitor PRIVATE -Wall -Wextra)
+endif()
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ clean:
 test:
 	mkdir -p build && \
     cd build && \
-    cmake .. && \
+    cmake -D TEST=ON .. && \
     cmake --build . && \
     ctest --output-on-failure


### PR DESCRIPTION
Originally we were just commenting out the CMake instructions for build when developing on MacOS and would uncomment when we pushed to our Linux machine (RaspberryPi) to run the build.

To fix we have set a CMake conditional called `TEST` (either `OFF` or `ON`) so that when running `make test` we use the `cmake -D TEST=ON` conditional flag and avoid having to comment and uncomment the build instructions. If the `TEST` flag is set to `OFF` then it will just build normally and not run any tests.