### PR TITLE
Add CPU Utilization

### DIFF
--- a/include/linux_parser.h
+++ b/include/linux_parser.h
@@ -39,7 +39,7 @@ enum CPUStates {
   kGuest_,
   kGuestNice_
 };
-std::vector<std::string> CpuUtilization();
+float CpuUtilization();
 long Jiffies();
 long ActiveJiffies();
 long ActiveJiffies(int pid);

--- a/include/processor.h
+++ b/include/processor.h
@@ -1,12 +1,17 @@
-#ifndef PROCESSOR_H
-#define PROCESSOR_H
+#pragma once
+
+#include "linux_parser.h"
+#include <vector>
 
 class Processor {
- public:
-  float Utilization();  // TODO: See src/processor.cpp
+public:
+    void AddToVector();
+    float Utilization();  // TODO: See src/processor.cpp
+
 
   // TODO: Declare any necessary private members
- private:
+private:
+    std::vector<float> cpu_utilization_t {LinuxParser::CpuUtilization()};
+    float total_utilization{0};
 };
 
-#endif

--- a/src/linux_parser.cpp
+++ b/src/linux_parser.cpp
@@ -191,8 +191,10 @@ long LinuxParser::IdleJiffies() {
     return idle_jif;
 }
 
-// TODO: Read and return CPU utilization
-vector<string> LinuxParser::CpuUtilization() { return {}; }
+// DONE
+float LinuxParser::CpuUtilization() {
+    return (float)ActiveJiffies() / (float)Jiffies();
+}
 
 // DONE
 int LinuxParser::TotalProcesses() {

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -6,15 +6,13 @@ void Processor::AddToVector() {
         this->cpu_utilization_t.erase(this->cpu_utilization_t.begin());
     } else {
         this->cpu_utilization_t.push_back(LinuxParser::CpuUtilization());
+        this->total_utilization += this->cpu_utilization_t.back();
     }
 }
 
 // TODO: Return the aggregate CPU utilization
 float Processor::Utilization() {
     Processor::AddToVector();
-    for (float i: this->cpu_utilization_t) {
-        this->total_utilization += i;
-    }
     return total_utilization / this->cpu_utilization_t.size();
 }
 

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -1,4 +1,20 @@
 #include "processor.h"
 
+void Processor::AddToVector() {
+    while (true) {
+        if (this->cpu_utilization_t.size() > 10) {
+            this->cpu_utilization_t.pop_back();
+        } else {
+            this->cpu_utilization_t.push_back(LinuxParser::CpuUtilization());
+        }
+    }
+}
+
 // TODO: Return the aggregate CPU utilization
-float Processor::Utilization() { return 0.0; }
+float Processor::Utilization() {
+    for (float i: this->cpu_utilization_t) {
+        this->total_utilization += i;
+    }
+    return total_utilization / this->cpu_utilization_t.size();
+}
+

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -1,13 +1,11 @@
 #include "processor.h"
 
 void Processor::AddToVector() {
-    while (true) {
-        if (this->cpu_utilization_t.size() > 10) {
-            this->total_utilization -= this->cpu_utilization_t.front();
-            this->cpu_utilization_t.erase(this->cpu_utilization_t.begin());
-        } else {
-            this->cpu_utilization_t.push_back(LinuxParser::CpuUtilization());
-        }
+    if (this->cpu_utilization_t.size() > 10) {
+        this->total_utilization -= this->cpu_utilization_t.front();
+        this->cpu_utilization_t.erase(this->cpu_utilization_t.begin());
+    } else {
+        this->cpu_utilization_t.push_back(LinuxParser::CpuUtilization());
     }
 }
 

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -12,6 +12,7 @@ void Processor::AddToVector() {
 
 // TODO: Return the aggregate CPU utilization
 float Processor::Utilization() {
+    AddToVector();
     for (float i: this->cpu_utilization_t) {
         this->total_utilization += i;
     }

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -3,7 +3,8 @@
 void Processor::AddToVector() {
     while (true) {
         if (this->cpu_utilization_t.size() > 10) {
-            this->cpu_utilization_t.pop_back();
+            this->total_utilization -= this->cpu_utilization_t.front();
+            this->cpu_utilization_t.erase(this->cpu_utilization_t.begin());
         } else {
             this->cpu_utilization_t.push_back(LinuxParser::CpuUtilization());
         }
@@ -12,7 +13,7 @@ void Processor::AddToVector() {
 
 // TODO: Return the aggregate CPU utilization
 float Processor::Utilization() {
-    AddToVector();
+    Processor::AddToVector();
     for (float i: this->cpu_utilization_t) {
         this->total_utilization += i;
     }


### PR DESCRIPTION
Added functionality to `processor.cpp` to show an approximation of CPU in the moment using the average utilization of a given set of captured CPU utilization info. The method fills and dumps a vector using FIFO bringing in and dropping one at a time. 

```cpp
void Processor::AddToVector() {
    if (this->cpu_utilization_t.size() > 10) {
        this->total_utilization -= this->cpu_utilization_t.front();
        this->cpu_utilization_t.erase(this->cpu_utilization_t.begin());
    } else {
        this->cpu_utilization_t.push_back(LinuxParser::CpuUtilization());
        this->total_utilization += this->cpu_utilization_t.back();
    }
}
```

In the code above you can switch up the length of the vector that stores captured CPU utilization info by configuring the parameter in the first `if` statement.